### PR TITLE
Update VRPlayerItemAdapter.cs

### DIFF
--- a/Assets/UnZENity-VR/Scripts/Adapters/Player/VRPlayerItemAdapter.cs
+++ b/Assets/UnZENity-VR/Scripts/Adapters/Player/VRPlayerItemAdapter.cs
@@ -26,7 +26,10 @@ namespace GUZ.VR.Adapters.Player
                 return;
 
             // In Gothic, Items have no physics when lying around. We need to activate physics for HVR to properly move items into our hands.
-            grabbable.GetComponent<Rigidbody>().isKinematic = false;
+            if (grabbable.TryGetComponent<Rigidbody>(out var rb))
+            {
+                rb.isKinematic = false;
+            }
         }
 
     }


### PR DESCRIPTION
only added a check if Rigidbody is not null before setting isKinematic to false 
This script assumed everything grabbable will have a rigidbody 
As a result, ladders were not working.
It was also conflicting with the climbing system that I was working on.